### PR TITLE
discard the buffer (link.csv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Github repository: *github.com/movestore/link-r-python*
 This repository contains the code for both Apps that link R and Python (R to Python and Python to R). These Apps are special as they run two programming languages, thus allowing to link R Apps and Python Apps. They work with move2 on the R side and MovingPandas TrajectoryCollection on the Python side.
 
 ## Documentation
-Both Apps create out of the input data two .csv files `link.csv`and `meta.csv`. The former contains the data frame of the complete set of locations with all attributes, the latter transfers information about timezone and data projection between the two languages. The two csv files will then be used in the receiving language to create the proper data object.
+Both Apps create out of the input data one .csv file `meta.csv`. It contains transfers information about timezone and data projection between the two languages. The two csv files will then be used in the receiving language to create the proper data object.
 
 **R to Python**: This App reads as input move2_loc in R, there transfers the data to csv files (see above), reads the information from those files into Python and creates a MovingPandas TrajectoryCollection as output. This output can then be used as input in Python Apps (of that IO type).
 

--- a/python/csv_2_pickle.py
+++ b/python/csv_2_pickle.py
@@ -3,7 +3,7 @@ import os
 
 if __name__ == '__main__':
     TransformToPickle().convert(
-        input_data_file_name=os.environ.get('LINK_R_PYTHON_BUFFER', '/tmp/artifacts/link.csv'),
+        input_data_file_name=os.environ.get('LINK_R_PYTHON_BUFFER', '/tmp/link.csv'),
         input_meta_file_name=os.environ.get('LINK_R_PYTHON_META', '/tmp/artifacts/meta.csv'),
         output_file_name=os.environ['OUTPUT_FILE']
     )

--- a/python/pickle_2_csv.py
+++ b/python/pickle_2_csv.py
@@ -4,6 +4,6 @@ import os
 if __name__ == '__main__':
     TransformToCsv().convert(
         input_data_file_name=os.environ['SOURCE_FILE'],
-        output_file_name=os.environ.get('LINK_R_PYTHON_BUFFER', '/tmp/artifacts/link.csv'),
+        output_file_name=os.environ.get('LINK_R_PYTHON_BUFFER', '/tmp/link.csv'),
         output_meta_file_name=os.environ.get('LINK_R_PYTHON_META', '/tmp/artifacts/meta.csv')
     )

--- a/python2r.sh
+++ b/python2r.sh
@@ -7,5 +7,11 @@
 #set -o nounset
 set -e
 
+set -a
+# do not provide the buffer (link.csv) as artifact; it is too big and not really useful
+: ${LINK_R_PYTHON_BUFFER:=/tmp/link.csv}
+: ${LINK_R_PYTHON_META:=/tmp/artifacts/meta.csv}
+set +a
+
 (cd python && conda activate "$HOME"/co-pilot-r/python-env && python pickle_2_csv.py)
 (cd r && Rscript csv_2_rds.R)

--- a/r/co-pilot-sdk.R
+++ b/r/co-pilot-sdk.R
@@ -32,8 +32,10 @@ Sys.setenv(
     SOURCE_FILE = inputFileName, 
     OUTPUT_FILE = outputFileName, 
     ERROR_FILE="./data/output/error.log", 
-    APP_ARTIFACTS_DIR ="./data/output/"
+    APP_ARTIFACTS_DIR ="./data/output/",
+    LINK_R_PYTHON_META="./data/output/meta.csv",
+    LINK_R_PYTHON_BUFFER="./data/output/link.csv"
 )
 
 source("rds_2_csv.R")
-#source("csv_2_rds.R")
+source("csv_2_rds.R")

--- a/r/co-pilot-sdk.R
+++ b/r/co-pilot-sdk.R
@@ -36,4 +36,4 @@ Sys.setenv(
 )
 
 source("rds_2_csv.R")
-source("csv_2_rds.R")
+#source("csv_2_rds.R")

--- a/r/csv_2_rds.R
+++ b/r/csv_2_rds.R
@@ -12,9 +12,9 @@ tryCatch(
     Sys.setenv(tz="UTC")
     
     # always includes "coords_x", "coords_y"
-    datapy <- read.csv(appArtifactPath("link.csv"),header=TRUE)
+    datapy <- read.csv(Sys.getenv(x = "LINK_R_PYTHON_BUFFER"),header=TRUE)
     # always includes crs, tzone, timeColName, trackIdColName
-    meta <- read.csv(appArtifactPath("meta.csv"),header=TRUE) 
+    meta <- read.csv(Sys.getenv(x = "LINK_R_PYTHON_META"),header=TRUE)
     
     if (dim(datapy)[1]==0) result <- NULL else
     {

--- a/r/rds_2_csv.R
+++ b/r/rds_2_csv.R
@@ -18,7 +18,7 @@ tryCatch(
       prj <- st_crs(data)[[1]] 
       tz <- attr(mt_time(data),'tzone')
       meta <- data.frame(crs=c(prj), tzone=c(tz), timeColName=mt_time_column(data), trackIdColName=mt_track_id_column(data))
-      write.csv(meta,appArtifactPath("meta.csv"),row.names=FALSE)
+      write.csv(meta,Sys.getenv(x = "LINK_R_PYTHON_META"),row.names=FALSE)
       
       ## get link.csv
       data <- mt_as_event_attribute(data, names(mt_track_data(data)))
@@ -42,7 +42,7 @@ tryCatch(
       # }
       # # if no local.taxon given, then set NA (Not Available)
       
-      write.csv(data.csv,appArtifactPath("link.csv"),row.names=FALSE)
+      write.csv(data.csv,Sys.getenv(x = "LINK_R_PYTHON_BUFFER"),row.names=FALSE)
   
     },
     error = function(e)

--- a/r/renv/settings.json
+++ b/r/renv/settings.json
@@ -7,6 +7,8 @@
     "Depends",
     "LinkingTo"
   ],
+  "ppm.enabled": null,
+  "ppm.ignored.urls": [],
   "r.version": [],
   "snapshot.type": "implicit",
   "use.cache": true,

--- a/r2python.sh
+++ b/r2python.sh
@@ -7,5 +7,11 @@
 #set -o nounset
 set -e
 
+set -a
+# do not provide the buffer (link.csv) as artifact; it is too big and not really useful
+: ${LINK_R_PYTHON_BUFFER:=/tmp/link.csv}
+: ${LINK_R_PYTHON_META:=/tmp/artifacts/meta.csv}
+set +a
+
 (cd r && Rscript rds_2_csv.R)
 (cd python && conda activate "$HOME"/co-pilot-r/python-env && python csv_2_pickle.py)


### PR DESCRIPTION
Hello @annescharf,

this PR discards the buffer-file (`link.csv`). The file is only accessible during the transformation by the app only. With this change the file is not a MoveApps _artifacts_ anymore. So it is not downloadable by the user anymore.

I discussed this with @andreakoelzsch . Background is:

- the file `link.csv` can become very large. MoveApps has to persist the file.
- the file content contains a lot of redundant information; for most MoveApps user the file content is useless